### PR TITLE
Allow optimizing over Bigfloat intervals

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,21 +1,13 @@
 name = "IntervalOptimisation"
 uuid = "c7c68f13-a4a2-5b9a-b424-07d005f8d9d2"
-version = "0.4.1" 
-
-[compat]
-DataStructures = "≥ 0.9.0"
-ForwardDiff = "≥ 0.8.0"
-IntervalArithmetic = "≥ 0.15.0"
-IntervalConstraintProgramming = "≥ 0.9.0"
-IntervalRootFinding = "≥ 0.4.0"
-julia = "≥ 1.0.0"
+version = "0.4.1"
 
 [deps]
-DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
-IntervalConstraintProgramming = "138f1668-1576-5ad7-91b9-7425abbf3153"
-IntervalRootFinding = "d2bf35a9-74e0-55ec-b149-d360ff49b807"
+
+[compat]
+IntervalArithmetic = "0.15, 0.16"
+julia = "1.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IntervalOptimisation"
 uuid = "c7c68f13-a4a2-5b9a-b424-07d005f8d9d2"
-version = "0.4.0" 
+version = "0.4.1" 
 
 [compat]
 DataStructures = "≥ 0.9.0"

--- a/src/IntervalOptimisation.jl
+++ b/src/IntervalOptimisation.jl
@@ -13,7 +13,7 @@ using .SortedVectors
 include("HeapedVectors.jl")
 using .HeapedVectors
 
-using IntervalArithmetic, IntervalRootFinding
+using IntervalArithmetic
 
 include("optimise.jl")
 

--- a/src/optimise.jl
+++ b/src/optimise.jl
@@ -1,4 +1,7 @@
-﻿"""
+﻿numeric_type(::Interval{T}) where {T} = T
+numeric_type(::IntervalBox{N, T}) where {N, T} = T
+
+"""
     minimise(f, X, structure = SortedVector, tol=1e-3)
     or
     minimise(f, X, structure = HeapedVector, tol=1e-3)
@@ -16,11 +19,12 @@ For higher-dimensional functions ``f:\\mathbb{R}^n \\to \\mathbb{R}``, `f` must 
 Returns an interval containing the global minimum, and a list of boxes that contain the minimisers.
 """
 function minimise(f, X::T; structure = HeapedVector, tol=1e-3) where {T}
-
+    nT = numeric_type(X)
+    
     # list of boxes with corresponding lower bound, arranged according to selected structure :
-    working = structure([(X, ∞)], x->x[2])
+    working = structure([(X, nT(∞))], x->x[2])
     minimizers = T[]
-    global_min = ∞  # upper bound
+    global_min = nT(∞)  # upper bound
 
     num_bisections = 0
 

--- a/test/heaped_vector.jl
+++ b/test/heaped_vector.jl
@@ -1,7 +1,7 @@
 using IntervalOptimisation
 using Test
 
-const HeapedVector = IntervalOptimisation.HeapedVector
+using IntervalOptimisation: HeapedVector
 
 @testset "heap" begin
 	

--- a/test/optimise.jl
+++ b/test/optimise.jl
@@ -1,7 +1,16 @@
 using IntervalArithmetic, IntervalOptimisation
 using Test
+using IntervalOptimisation: numeric_type
 
 @testset "IntervalOptimisation tests" begin
+    @testset "numeric_type" begin
+        x = -10..10
+        big_x = big(x)
+        @test numeric_type(x) == Float64
+        @test numeric_type(big_x) == BigFloat
+        @test numeric_type(IntervalBox(x, x)) == Float64
+        @test numeric_type(IntervalBox(big_x, big_x)) == BigFloat
+    end
 
     @testset "Minimise in 1D using default data structure i.e HeapedVector" begin
         global_min, minimisers = minimise(x->x, -10..10)

--- a/test/optimise.jl
+++ b/test/optimise.jl
@@ -15,6 +15,12 @@ using Test
         @test length(maximisers) == 1
         @test maximisers[1] ⊆ 9.999 .. 10
 
+        # same but with BigFloats
+        global_min, minimisers = minimise(x->x, -big(10.0)..big(10.0))
+        @test global_min ⊆ -10 .. -9.999
+        @test length(minimisers) == 1
+        @test minimisers[1] ⊆ -10 .. -9.999
+
         global_min, minimisers = minimise(x->x^2, -10..11, tol = 1e-10)
         @test global_min ⊆ 0..1e-20
         @test length(minimisers) == 1
@@ -28,7 +34,7 @@ using Test
 
     for Structure in (SortedVector, HeapedVector)
 
-        @testset "Minimise in 1D using SoretedVector" begin
+        @testset "Minimise in 1D using SortedVector" begin
             global_min, minimisers = minimise(x->x, -10..10, structure = Structure)
             @test global_min ⊆ -10 .. -9.999
             @test length(minimisers) == 1
@@ -39,6 +45,12 @@ using Test
             @test global_max ⊆ 9.999 .. 10
             @test length(maximisers) == 1
             @test maximisers[1] ⊆ 9.999 .. 10
+
+            # same but with BigFloats
+            global_min, minimisers = minimise(x->x, -big(10.0)..big(10.0), structure = Structure)
+            @test global_min ⊆ -10 .. -9.999
+            @test length(minimisers) == 1
+            @test minimisers[1] ⊆ -10 .. -9.999
 
             global_min, minimisers = minimise(x->x^2, -10..11, tol=1e-10, structure = Structure)
             @test global_min ⊆ 0..1e-20
@@ -73,6 +85,12 @@ using Test
             @test global_max ⊆ 199.9..200
             m = (9.99..10)
             @test all(X ⊆ m × m || X ⊆ -m × m || X ⊆ m × -m || X ⊆ -m × -m for X in maximisers)
+
+            # same but with BigFloats
+            global_min, minimisers = minimise( X -> ( (x,y) = X; x^2 + y^2 ), (-big(10.0)..big(10.0)) × (-big(10.0)..big(10.0)), structure = Structure )
+            @test global_min ⊆ 0..1e-7
+            @test all(X ⊆ big(-1e-3..1e3) × big(-1e-3..1e-3) for X in minimisers)
+
         end
 
     end

--- a/test/sorted_vector.jl
+++ b/test/sorted_vector.jl
@@ -1,7 +1,7 @@
 using IntervalOptimisation
 using Test
 
-const SortedVector = IntervalOptimisation.SortedVector
+using IntervalOptimisation: SortedVector
 
 @testset "SortedVector" begin
 


### PR DESCRIPTION
I looked for something like the `numeric_type` function I introduce here in IntervalArithmetic.jl but didn't see anything, so I just defined it here. Fixes #43.