### PR TITLE
Fix Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,7 @@ version = "0.5.1"
 IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 
 [compat]
-IntervalArithmetic = "0.22 - 1"
+IntervalArithmetic = "0.22 - 0.23, 1"
 julia = "1.9"
 
 [extras]


### PR DESCRIPTION
This fixes a problem with registration:

> The following dependencies do not have a [compat] entry that is upper-bounded and only includes a finite number of breaking releases: IntervalArithmetic