### PR TITLE
file -> files for codecov

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,4 +31,4 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v6
         with:
-          file: lcov.info
+          files: lcov.info


### PR DESCRIPTION
It was renamed. @OlivierHnt We also need to add the `CODECOV_TOKEN` but I cannot see it on codecov.